### PR TITLE
Replaced tree-sitter and improved highlighting

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -4,11 +4,11 @@ schema_version = 1
 description = "Bitbake language support for the Zed editor"
 repository = "https://github.com/anikinmd/zed_bitbake"
 authors = ["Mikhail Anikin <anikin.mikhail.d@gmail.com>"]
-version = "0.0.2"
+version = "0.0.3"
 
 [grammars.bitbake]
-repository = "https://github.com/tree-sitter-grammars/tree-sitter-bitbake"
-commit = "a5d04fdb5a69a02b8fa8eb5525a60dfb5309b73b"
+repository = "https://github.com/idillon-sfl/tree-sitter-bitbake"
+commit = "bc577daab90b551ad1dc42c3373db2cb7c43857d"
 
 [language_servers.bitbake]
 name = "bitbake"

--- a/languages/bitbake/folds.scm
+++ b/languages/bitbake/folds.scm
@@ -1,0 +1,29 @@
+[
+  (function_definition)
+  (anonymous_python_function)
+  (python_function_definition)
+
+  (while_statement)
+  (for_statement)
+  (if_statement)
+  (with_statement)
+  (try_statement)
+
+  (import_from_statement)
+  (parameters)
+  (argument_list)
+
+  (parenthesized_expression)
+  (generator_expression)
+  (list_comprehension)
+  (set_comprehension)
+  (dictionary_comprehension)
+
+  (tuple)
+  (list)
+  (set)
+  (dictionary)
+
+  (string)
+  (python_string)
+] @fold

--- a/languages/bitbake/highlights.scm
+++ b/languages/bitbake/highlights.scm
@@ -1,4 +1,3 @@
-
 ; Includes
 
 [
@@ -7,7 +6,7 @@
   "require"
   "export"
   "import"
-] @include
+] @keyword
 
 ; Keywords
 
@@ -95,7 +94,7 @@
   "OVERRIDES"
   "$BB_ENV_PASSTHROUGH"
   "$BB_ENV_PASSTHROUGH_ADDITIONS"
-] @variable.builtin
+] @variable.special
 
 ; Reset highlighting in f-string interpolations
 (interpolation) @none

--- a/languages/bitbake/indents.scm
+++ b/languages/bitbake/indents.scm
@@ -1,0 +1,130 @@
+[
+  (import_from_statement)
+
+  (parenthesized_expression)
+  (generator_expression)
+  (list_comprehension)
+  (set_comprehension)
+  (dictionary_comprehension)
+
+  (tuple_pattern)
+  (list_pattern)
+  (binary_operator)
+
+  (lambda)
+
+  (concatenated_string)
+] @indent.begin
+
+((list) @indent.align
+ (#set! indent.open_delimiter "[")
+ (#set! indent.close_delimiter "]")
+)
+((dictionary) @indent.align
+ (#set! indent.open_delimiter "{")
+ (#set! indent.close_delimiter "}")
+)
+((set) @indent.align
+ (#set! indent.open_delimiter "{")
+ (#set! indent.close_delimiter "}")
+)
+
+((for_statement) @indent.begin
+ (#set! indent.immediate 1))
+((if_statement) @indent.begin
+ (#set! indent.immediate 1))
+((while_statement) @indent.begin
+ (#set! indent.immediate 1))
+((try_statement) @indent.begin
+ (#set! indent.immediate 1))
+(ERROR "try" ":" @indent.begin (#set! indent.immediate 1))
+((python_function_definition) @indent.begin
+ (#set! indent.immediate 1))
+((function_definition) @indent.begin
+ (#set! indent.immediate 1))
+((anonymous_python_function) @indent.begin
+ (#set! indent.immediate 1))
+((with_statement) @indent.begin
+ (#set! indent.immediate 1))
+
+(if_statement
+  condition: (parenthesized_expression) @indent.align
+  (#set! indent.open_delimiter "(")
+  (#set! indent.close_delimiter ")")
+  (#set! indent.avoid_last_matching_next 1))
+(while_statement
+  condition: (parenthesized_expression) @indent.align
+  (#set! indent.open_delimiter "(")
+  (#set! indent.close_delimiter ")")
+  (#set! indent.avoid_last_matching_next 1))
+
+(ERROR "(" @indent.align (#set! indent.open_delimiter "(") (#set! indent.close_delimiter ")") . (_)) 
+((argument_list) @indent.align
+ (#set! indent.open_delimiter "(")
+ (#set! indent.close_delimiter ")"))
+((parameters) @indent.align
+ (#set! indent.open_delimiter "(")
+ (#set! indent.close_delimiter ")")
+ (#set! indent.avoid_last_matching_next 1))
+((tuple) @indent.align
+ (#set! indent.open_delimiter "(")
+ (#set! indent.close_delimiter ")"))
+
+(ERROR "[" @indent.align (#set! indent.open_delimiter "[") (#set! indent.close_delimiter "]") . (_)) 
+
+(ERROR "{" @indent.align (#set! indent.open_delimiter "{") (#set! indent.close_delimiter "}") . (_)) 
+
+[
+  (break_statement)
+  (continue_statement)
+] @indent.dedent
+
+(ERROR
+  (_) @indent.branch ":" .
+  (#lua-match? @indent.branch "^else"))
+
+(ERROR
+  (_) @indent.branch @indent.dedent ":" .
+  (#lua-match? @indent.branch "^elif"))
+
+(parenthesized_expression ")" @indent.end)
+(generator_expression ")" @indent.end)
+(list_comprehension "]" @indent.end)
+(set_comprehension "}" @indent.end)
+(dictionary_comprehension "}" @indent.end)
+
+(tuple_pattern ")" @indent.end)
+(list_pattern "]" @indent.end)
+
+(function_definition "}" @indent.end)
+(anonymous_python_function "}" @indent.end)
+
+
+(return_statement
+  [
+    (_) @indent.end
+    (_
+      [
+        (_)
+        ")"
+        "}"
+        "]"
+      ] @indent.end .)
+    (attribute 
+      attribute: (_) @indent.end)
+    (call
+      arguments: (_ ")" @indent.end))
+    "return" @indent.end
+  ] .)
+
+[
+  ")"
+  "]"
+  "}"
+  (elif_clause)
+  (else_clause)
+  (except_clause)
+  (finally_clause)
+] @indent.branch
+
+(string) @indent.auto

--- a/languages/bitbake/injections.scm
+++ b/languages/bitbake/injections.scm
@@ -1,0 +1,14 @@
+(call
+  function: (attribute
+              object: (python_identifier) @_re)
+  arguments: (argument_list (python_string
+                              (string_content) @content) @_string)
+  (#eq? @_re "re")
+  (#lua-match? @_string "^r.*")
+  (#set! language "regex"))
+
+((shell_content) @content
+  (#set! language "bash"))
+
+((comment) @injection.content
+ (#set! language "comment"))

--- a/languages/bitbake/locals.scm
+++ b/languages/bitbake/locals.scm
@@ -1,0 +1,99 @@
+; References
+[
+  (python_identifier)
+  (identifier)
+] @reference
+
+; Imports
+(aliased_import
+  alias: (python_identifier) @definition.import)
+(import_statement
+  name: (dotted_name ((python_identifier) @definition.import)))
+(import_from_statement
+  name: (dotted_name ((python_identifier) @definition.import)))
+
+; Function with parameters, defines parameters
+(parameters
+  (python_identifier) @definition.parameter)
+
+(default_parameter
+  (python_identifier) @definition.parameter)
+
+(typed_parameter
+  (python_identifier) @definition.parameter)
+
+(typed_default_parameter
+  (python_identifier) @definition.parameter)
+
+; *args parameter
+(parameters
+  (list_splat_pattern
+    (python_identifier) @definition.parameter))
+
+; **kwargs parameter
+(parameters
+  (dictionary_splat_pattern
+    (python_identifier) @definition.parameter))
+
+; Function defines function and scope
+((python_function_definition
+  name: (python_identifier) @definition.function) @scope
+ (#set! definition.function.scope "parent"))
+
+(function_definition (identifier) @definition.function)
+
+(anonymous_python_function (identifier) @definition.function)
+
+;;; Loops
+; not a scope!
+(for_statement
+  left: (pattern_list
+          (python_identifier) @definition.var))
+(for_statement
+  left: (tuple_pattern
+          (python_identifier) @definition.var))
+(for_statement
+  left: (python_identifier) @definition.var)
+
+; not a scope!
+;(while_statement) @scope
+
+; for in list comprehension
+(for_in_clause
+  left: (python_identifier) @definition.var)
+(for_in_clause
+  left: (tuple_pattern
+          (python_identifier) @definition.var))
+(for_in_clause
+  left: (pattern_list
+          (python_identifier) @definition.var))
+
+(dictionary_comprehension) @scope
+(list_comprehension) @scope
+(set_comprehension) @scope
+
+;;; Assignments
+
+(assignment
+ left: (python_identifier) @definition.var)
+
+(assignment
+ left: (pattern_list
+   (python_identifier) @definition.var))
+(assignment
+ left: (tuple_pattern
+   (python_identifier) @definition.var))
+
+(assignment
+ left: (attribute
+   (python_identifier)
+   (python_identifier) @definition.field))
+
+(variable_assignment (identifier) operator: [ "=" "?=" "??=" ":=" ] @definition.var)
+
+; Walrus operator  x := 1
+(named_expression
+  (python_identifier) @definition.var)
+
+(as_pattern
+  alias: (as_pattern_target) @definition.var)


### PR DESCRIPTION
This commit replaces tree-sitter to the same as used in vscode.
Also it introduces zed-compatible code injections for bash functions and fixes some keywords highlighting

Fix for the #2 